### PR TITLE
Adding docker submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker"]
+	path = docker
+	url = https://github.com/Trinketer22/func_docker


### PR DESCRIPTION
Hey!
I think this one might come in handy to temporary relief most of the pain that comes with binaries/toncli versions issues.
At least till the day when `pip install toncli` will just work with all the new features.
New tests are **far better** than the old ones s people using *toncli*, are going to need to switch to those ASAP.
Otherwise legacy code is going to continue to grow and cause pain to everyone.
Only way i see to quickly and reliably do it at this stage is moving towards containerized development.
What i'm proposing with this PR is to make some *toncli* approved container for people to work from.

I doesn't have to be my container, because it's not tested much yet at the moment, but it would be much easier to start if there was one.

Also there is probably better way to let people know about the existence of the new tests. 
Not many people read  [docs/advanced](https://github.com/disintar/toncli/tree/master/docs/advanced) till they feel completely lost.

I think it would be much better if there was at least a separate paragraph in [quickstart](https://github.com/disintar/toncli/blob/master/docs/quick_start_guide.md) more insistingly leading towards [how tests work](https://github.com/disintar/toncli/blob/master/docs/advanced/func_tests_new.md).
Or maybe even on the front README.md

Has at least to do with issue:#36
