### PR TITLE
Project directories now can be added dynamically

### DIFF
--- a/src/toncli/modules/utils/parsers/parser_utils.py
+++ b/src/toncli/modules/utils/parsers/parser_utils.py
@@ -2,6 +2,7 @@ import argparse
 import textwrap
 from typing import Any
 from toncli.modules.utils.text.text_utils import TextUtils
+from toncli.modules.utils.system.conf import get_projects
 
 class ParserUtil():
     subparser: Any
@@ -27,7 +28,7 @@ class ParserUtil():
     def set_project_parser(self):
         parser_project = self.subparser.add_parser('start',
                                           description='Create new project structure based on example project')
-        parser_project.add_argument('project', choices=['wallet', 'external_data', 'external_code'],
+        parser_project.add_argument('project', choices=get_projects(),
                                     help="Which default project to bootstrap")
 
         parser_project.add_argument("--name", "-n", default=None, type=str, help='New project folder name')

--- a/src/toncli/modules/utils/system/conf.py
+++ b/src/toncli/modules/utils/system/conf.py
@@ -44,6 +44,12 @@ def getcwd():
 
     return path
 
+def get_subdirs( path: str ) -> list:
+    return [ sub_dir.name for sub_dir in os.scandir( path ) if sub_dir.is_dir() ]
+
+def get_projects() -> list:
+    project_loc = os.path.join( project_root, "projects" )
+    return get_subdirs( project_loc )
 
 # Create if not exist
 if not os.path.exists(os.path.abspath(f"{config_folder}/config.ini")):


### PR DESCRIPTION
I think it makes sense to make projects parser options to load dynamically .
Otherwise we would have to add changes to the [parser-utils](https://github.com/disintar/toncli/blob/master/src/toncli/modules/utils/parsers/parser_utils.py) every time module is added and that would increase chances of breaking something while doing so.

Also maybe at some point help msgs from new modules would probably be better to migrate to *project.yml* rather than editing [text_utils](https://github.com/disintar/toncli/blob/master/src/toncli/modules/utils/text/text_utils.py) for the same reasons.

I know modules are not added often, but we gotta hope for the best right?