### PR TITLE
Asm.fif update needed.

### DIFF
--- a/src/toncli/lib/fift-libs/Asm.fif
+++ b/src/toncli/lib/fift-libs/Asm.fif
@@ -1,15 +1,17 @@
 library TVM_Asm
 // simple TVM Assembler
 variable @atend
+variable @was-split
+false @was-split !
 { "not in asm context" abort } @atend !
 { `normal eq? not abort"must be terminated by }>" } : @normal?
 { @atend @ 1 { @atend ! @normal? } does @atend ! } : @pushatend
 { @pushatend <b } : <{
 { @atend @ execute } : @endblk
-{ `normal @endblk } : }>
+{ false @was-split ! `normal @endblk } : }>
 { }> b> } : }>c
 { }>c <s } : }>s
-{ @atend @ 2 { @atend ! rot b> ref, swap @endblk } does @atend ! <b } : @|
+{ @atend @ 2 { true @was-split ! @atend ! rot b> ref, swap @endblk } does @atend ! <b } : @|
 { @atend @ 3 { @atend ! 2swap rot execute } does @atend ! <b } : @doafter<{
 { over brembits <= } : @havebits
 { rot + -rot + swap } : pair+
@@ -334,9 +336,14 @@ x{A926} @Defop RSHIFTC
 x{A935} @Defop(8u+1) RSHIFTR#
 x{A936} @Defop(8u+1) RSHIFTC#
 x{A938} @Defop(8u+1) MODPOW2#
+x{A939} @Defop(8u+1) MODPOW2R#
+x{A93A} @Defop(8u+1) MODPOW2C#
 x{A984} @Defop MULDIV
 x{A985} @Defop MULDIVR
+x{A988} @Defop MULMOD
 x{A98C} @Defop MULDIVMOD
+x{A98D} @Defop MULDIVMODR
+x{A98E} @Defop MULDIVMODC
 x{A9A4} @Defop MULRSHIFT
 x{A9A5} @Defop MULRSHIFTR
 x{A9A6} @Defop MULRSHIFTC
@@ -649,7 +656,7 @@ x{DB32} dup @Defop BRANCH @Defop RETBOOL
 x{DB34} @Defop CALLCC
 x{DB35} @Defop JMPXDATA
 { dup 1+ 0= { 16 + } if
-  <b x{DB36} rot 4 u, swap 4 u, @addopb
+  <b x{DB36} s, rot 4 u, swap 4 u, @addopb
 } : CALLCCARGS
 x{DB38} @Defop CALLXVARARGS
 x{DB39} @Defop RETVARARGS
@@ -717,34 +724,34 @@ recursive IFELSE-cont2 {
 { 1 { swap @normal? swap IFELSE-cont2 } does @doafter<{ } : @doifelse
 { 1 { swap @normal? IFELSE-cont2 } does @doafter<{ } : @doifnotelse
 {
-  { dup `else eq?
+  { dup `else eq? 
     { drop @doifelse }
     { dup `else: eq?
       { drop IFJMP-cont }
       { @normal? IF-cont
-      } cond
-    } cond
-  } @doafter<{
+      } cond 
+    } cond 
+  } @doafter<{ 
 } : IF:<{
 {
-  { dup `else eq?
+  { dup `else eq? 
     { drop @doifnotelse }
     { dup `else: eq?
       { drop IFNOTJMP-cont }
       { @normal? IFNOT-cont
-      } cond
-    } cond
-  } @doafter<{
+      } cond 
+    } cond 
+  } @doafter<{ 
 } : IFNOT:<{
 
 x{E304} @Defop CONDSEL
 x{E305} @Defop CONDSELCHK
 x{E308} @Defop IFRETALT
 x{E309} @Defop IFNOTRETALT
-{ <b x{E39_} swap 5 u, @addopb } : IFBITJMP
-{ <b x{E3B_} swap 5 u, @addopb } : IFNBITJMP
-{ <b x{E3D_} swap 5 u, swap ref, @addopb } : IFBITJMPREF
-{ <b x{E3F_} swap 5 u, swap ref, @addopb } : IFNBITJMPREF
+{ <b x{E39_} s, swap 5 u, @addopb } : IFBITJMP
+{ <b x{E3B_} s, swap 5 u, @addopb } : IFNBITJMP
+{ <b x{E3D_} s, swap 5 u, swap ref, @addopb } : IFBITJMPREF
+{ <b x{E3F_} s, swap 5 u, swap ref, @addopb } : IFNBITJMPREF
 
 x{E4} @Defop REPEAT
 x{E5} dup @Defop REPEATEND @Defop REPEAT:
@@ -762,12 +769,12 @@ x{EB} dup @Defop AGAINEND @Defop AGAIN:
 { }> PUSHCONT UNTIL } : }>UNTIL
 { { @normal? PUSHCONT UNTIL } @doafter<{ } : UNTIL:<{
 { PUSHCONT { @normal? PUSHCONT WHILE } @doafter<{ } : @dowhile
-{
-  { dup `do eq?
-    { drop @dowhile }
-    { `do: eq? not abort"`}>DO<{` expected" PUSHCONT WHILEEND
-    } cond
-  } @doafter<{
+{ 
+  { dup `do eq? 
+    { drop @dowhile } 
+    { `do: eq? not abort"`}>DO<{` expected" PUSHCONT WHILEEND 
+    } cond 
+  } @doafter<{ 
 } : WHILE:<{
 { }> PUSHCONT AGAIN } : }>AGAIN
 { { @normal? PUSHCONT AGAIN } @doafter<{ } : AGAIN:<{
@@ -787,11 +794,11 @@ x{E31B} dup @Defop AGAINENDBRK @Defop AGAINBRK:
 { { @normal? PUSHCONT UNTILBRK } @doafter<{ } : UNTILBRK:<{
 { PUSHCONT { @normal? PUSHCONT WHILEBRK } @doafter<{ } : @dowhile
 {
-  { dup `do eq?
-    { drop @dowhile }
+  { dup `do eq? 
+    { drop @dowhile } 
     { `do: eq? not abort"`}>DO<{` expected" PUSHCONT WHILEENDBRK
-    } cond
-  } @doafter<{
+    } cond 
+  } @doafter<{ 
 } : WHILEBRK:<{
 { }> PUSHCONT AGAINBRK } : }>AGAINBRK
 { { @normal? PUSHCONT AGAINBRK } @doafter<{ } : AGAINBRK:<{
@@ -817,8 +824,8 @@ x{ED1F} @Defop BLESSVARARGS
 { c4 PUSHCTR } : PUSHROOT
 { c4 POPCTR } : POPROOT
 x{ED6} dup @Defop(c) SETCONTCTR @Defop(c) SETCONT
-x{ED7} @Defop(c) SETRETCTR
-x{ED8} @Defop(c) SETALTCTR
+x{ED7} @Defop(c) SETRETCTR 
+x{ED8} @Defop(c) SETALTCTR 
 x{ED9} dup @Defop(c) POPSAVE @Defop(c) POPCTRSAVE
 x{EDA} dup @Defop(c) SAVE @Defop(c) SAVECTR
 x{EDB} dup @Defop(c) SAVEALT @Defop(c) SAVEALTCTR
@@ -902,9 +909,9 @@ x{F2FF} @Defop TRY
 x{F3} @Defop(4u,4u) TRYARGS
 { `catch @endblk } : }>CATCH<{
 { PUSHCONT { @normal? PUSHCONT TRY } @doafter<{ } : @trycatch
-{
+{ 
   { `catch eq? not abort"`}>CATCH<{` expected" @trycatch
-  } @doafter<{
+  } @doafter<{ 
 } : TRY:<{
 //
 // dictionary manipulation
@@ -1054,7 +1061,7 @@ x{F4A1} @Defop DICTUGETJMP
 x{F4A2} @Defop DICTIGETEXEC
 x{F4A3} @Defop DICTUGETEXEC
 { dup sbitrefs tuck 1 > swap 1 <> or abort"not a dictionary" swap 1 u@ over <> abort"not a dictionary" } : @chkdicts
-{ dup null? tuck { <s } ifnot drop not } : @chkdict
+{ dup null? tuck { <s } ifnot drop not } : @chkdict 
 { over @chkdict
   { swap <b x{F4A6_} s, swap ref, swap 10 u, @addopb }
   { nip swap NEWDICT swap PUSHINT }
@@ -1226,6 +1233,10 @@ variable asm-mode  1 asm-mode !
 } : PROGRAM{
 { over sbits < { s>c <b swap ref, b> <s } if } : @adj-long-proc
 { // i s l
+  dup 0< {
+    negate
+    @was-split @ { drop 0 } if
+  } if
   @adj-long-proc over @procdict @ @procdictkeylen
   idict!+ not abort"cannot define procedure, redefined?"
   @procdict !  2 2 @procinfo~!
@@ -1235,6 +1246,7 @@ variable asm-mode  1 asm-mode !
 { @have-procinfo? { 8 8 @procinfo~! } { drop } cond } : @proc-called
 { 1000 @def-proc } : PROC
 { 0 @def-proc } : PROCREF
+{ -1000 @def-proc } : PROCINLINE
 { @procdict @ @procdictkeylen idict@ abort"procedure already defined"
 } : @fail-ifdef
 { u@?+ { swap abort"first bits are not zeroes" } if } : @cut-zeroes
@@ -1244,6 +1256,7 @@ variable asm-mode  1 asm-mode !
 } : @PROC:<{
 { 1000 @PROC:<{ } : PROC:<{
 { 0 @PROC:<{ } : PROCREF:<{
+{ -1000 @PROC:<{ } : PROCINLINE:<{
 { dup @proc-called CALLDICT } dup : CALL : CALLDICT
 { dup @proc-called JMPDICT } dup : JMP : JMPDICT
 { dup @proc-called PREPAREDICT } dup : PREPARE : PREPAREDICT


### PR DESCRIPTION
Proper fix for all PROCINLINE issues like #56 and #55

Thing is that PROCINLINE is simply not defined at currently supplied *Asm.fif*

Replacing it with [SpyCheese current Asm.fif](https://github.com/SpyCheese/ton/blob/toncli-local/crypto/fift/lib/Asm.fif#L1259) fixes it.
As a proof try to compile this:
```
() recv_internal() {
}

( int ) hello () inline {
	return 1337;
}
```

`toncli build`
`toncli run build/contract.fif`

Unfortunately way proposed in #56 only helps with very specific use case instead of fixing core of the issue.