### PR TITLE
Run tests only if tests specified.

### DIFF
--- a/src/toncli/modules/utils/test/tests.py
+++ b/src/toncli/modules/utils/test/tests.py
@@ -33,7 +33,7 @@ class TestsRunner:
                     if config.name == item:
                         real_contracts.append(config)
         else:
-            real_contracts = self.project_config.contracts
+            real_contracts = list( filter( lambda p: len(p.func_tests_files_locations ) > 0, self.project_config.contracts ) )
 
         if not len(real_contracts):
             logger.error(f"😥 No contracts [{contracts}] are founded in project.yaml")


### PR DESCRIPTION
If you have 2 projects and only one has defined tests then TestRunner is
going to atempt to run [project_name]_tests.fif even if non generated.
Firt exception is going to be thrown.
So i think the best solution is just to not enter test processing loop
if there are no tests.