### PR TITLE
Set data.fif result as default c4 value for tests

### DIFF
--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -11,6 +11,10 @@ constant test_code         // save code cell as constant
 {{ verbose }} constant verbose
 {{ output_results }} constant output-results
 
+{% if contract_data|length %}
+"{{ contract_data }}" constant proj_data 
+{% endif %}
+
 "EQB36_EfYjFYMV8p_cxSYX61bA0FZ4B65ZNN6L8INY-5gL6w" true parse-load-address drop 2constant address
 
 // this is c7 that will be passed to test code
@@ -31,8 +35,17 @@ null                 // global_config
 variable @tests            // here we will store all test functions in a format [function_name, method_id]
 variable @prev_c4            // prev test c4
 variable @prev_c5            // prev test c5
+variable @init_c4 // Init value of c4
 null @prev_c4 !
 null @prev_c5 !
+
+// We usually (Eh) don't have procedures defined in data.fif so include returns just cell
+// What if someone adds method to it? No good. What can we do? 
+// IDK since we don't have a way to get stack size. Or do we?
+// Maybe move it to the very top before asm-mode changes ( L5 )?
+
+def? proj_data { proj_data include } { <b b>  } cond
+@init_c4 ! 
 
 variable @cnt        // here we will store tests list length
 @cnt 0!              // set as 0 by default
@@ -173,7 +186,7 @@ verbose 0>
     @' test_info second // get test function selector
     test_code <s // load func code as slice
 
-    <b b>           // always start with empty c4, developers could get prev-c4 from c7
+    @init_c4 @           // starts  empty or pre-initialized c4, developers could get prev-c4 from c7
     add-c4-c5-to-c7 // c7
     1000000000      // gas limit
     calc-vm-mode

--- a/src/toncli/modules/utils/test/tests.py
+++ b/src/toncli/modules/utils/test/tests.py
@@ -59,6 +59,7 @@ class TestsRunner:
                 'test_path': contract.to_save_tests_location,
                 'output_results': int(output_results),
                 'output_path': output_path,
+                'contract_data': contract.data,
                 'verbose': verbose
             }
 


### PR DESCRIPTION
Before we had to set_data() manually.
Now we can use fift script specified in project config *data* option