### PR TITLE
Fix test_defauilt_c4 when no data provided.

### DIFF
--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -44,7 +44,7 @@ null @prev_c5 !
 // IDK since we don't have a way to get stack size. Or do we?
 // Maybe move it to the very top before asm-mode changes ( L5 )?
 
-def? proj_data { proj_data include } { <b b>  } cond
+proj_data def? { proj_data include } { <b b>  } cond
 @init_c4 ! 
 
 variable @cnt        // here we will store tests list length


### PR DESCRIPTION
Thing is that **def?** is defined as **S - ?**
If used like `def? word` it attempts to push undefined word to stack
I was referring to:
[usage.fif](https://github.com/disintar/toncli/blob/master/src/toncli/projects/wallet/fift/usage.fif#L57)
while implementing it, but apearently it works there because
*body_fift_file* is always defined and that's being evaluated by cond
operator instead of result of def?