### PR TITLE
export_address_to_fift added to AbstractDeployer

### DIFF
--- a/src/toncli/modules/abstract/deployer.py
+++ b/src/toncli/modules/abstract/deployer.py
@@ -134,6 +134,15 @@ class AbstractDeployer:
 
         return addresses
 
+    def export_address_to_fift( self, path: str ):
+        addresses = self.get_address()
+
+        with open( path, "w", encoding='utf-8' ) as f:
+            logger.info(f"🦘 Exporing address to {gr}{self.owner_fift_path}{rs}")
+            f.write( addresses[0][0].replace( ":", " ") + " 2constant owner_raw\n" )
+            f.write( f'"{addresses[0][1]}" constant owner_address\n' )
+            f.write( f'"{addresses[0][2]}" constant owner_no_bounce\n' )
+
     def compile_func(self, contracts: List[TonProjectConfig] = None):
         """Compile func to code.fif"""
         # Build code

--- a/src/toncli/modules/deploy_wallet_contract.py
+++ b/src/toncli/modules/deploy_wallet_contract.py
@@ -26,6 +26,7 @@ class DeployWalletContract(AbstractDeployer):
         self.network = network
         self.workchain = workchain
         self.project_root = os.path.abspath(f"{config_folder}/wallet")
+        self.owner_fift_path = os.path.abspath(f"{config_folder}/fift-libs/OwnerAddr.fif") 
 
         # If files.yaml in func folder - it's older version of project structure, so migrate
         if os.path.exists(os.path.abspath(f"{self.project_root}/func/files.yaml")):
@@ -61,6 +62,8 @@ class DeployWalletContract(AbstractDeployer):
                     f"💎 About {gr}2 TON{rs} will be OK for 10-12 contracts\n"
                     f"🧪 Test coins can be found in {bl}@testgiver_ton_bot{rs} / @tondev")
 
+
+                self.export_address_to_fift( self.owner_fift_path );
                 sys.exit()
         else:
             self.project_config = ProjectConf(self.project_root)
@@ -71,6 +74,11 @@ class DeployWalletContract(AbstractDeployer):
             logger.info(
                 f"🦘 Found existing deploy-wallet [{gr}{self.addresses[0][1]}{rs}] (Balance: {balance}💎, "
                 f"Is inited: {is_inited}) in {config_folder}")
+
+            if not os.path.exists( self.owner_fift_path ):
+                self.export_address_to_fift( self.owner_fift_path )
+
+
 
     def send_ton(self, address: str, amount: float, quiet: bool = False):
         """Send ton to some address from DeployWallet"""


### PR DESCRIPTION
It's now used in deployer wallet to export contract address
to {config_folder}/fift-libs/OwnerAddr.fif