### PR TITLE
Fix gas limit comment

### DIFF
--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -190,7 +190,7 @@ verbose 0>
 
     @init_c4 @           // starts  empty or pre-initialized c4, developers could get prev-c4 from c7
     add-c4-c5-to-c7 // c7
-    1000000000      // gas limit
+    1000000000      // gas max
     calc-vm-mode
     runvmx
     // TODO: check what happens if it returns more elements

--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -190,7 +190,7 @@ verbose 0>
 
     @init_c4 @           // starts  empty or pre-initialized c4, developers could get prev-c4 from c7
     add-c4-c5-to-c7 // c7
-    1000000000      // gas max
+    1000000000      // gas max https://github.com/ton-blockchain/ton/blob/master/crypto/vm/vm.h#L38
     calc-vm-mode
     runvmx
     // TODO: check what happens if it returns more elements


### PR DESCRIPTION
This is actually gas_max and not gas_limit.
Try

 ```
 (int, int) get_gl() asm "GASLIMITSTEMP";
int __test_gl() {
      set_gas_limit(2000000000);
      (int gl, _) = get_gl();
      return gl;
}
```
Will return 10^9 due to:https://github.com/ton-blockchain/ton/blob/master/crypto/vm/vm.cpp#L418
This is important to know for accept_message related testing, because this value would never increase.
You have to set to lower gl inside the test case, and then compare to 10^9.