### PR TITLE
Abort run if tests are failed

### DIFF
--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -289,5 +289,11 @@ while  // run all tests
 
 make-esc"[1m" ^bold
 
+cr
 ."Final status: [" ^green ."SUCCESS" ^reset ."] - " @count_success @ (dump) ^bold type ." cases" ^reset cr
-."Final status: [" ^red ."FAILED" ^reset ."] - " @count_fail @ (dump) ^bold type ." cases" ^reset cr
+@count_fail @ dup 0> {
+    ."Final status: [" ^red ."FAILED" ^reset ."] - " (dump) ^bold type ." cases" ^reset cr
+    .s // this trick is for correct error porinting
+} if
+
+@count_fail @ 0> { {{ silent }} 0 = { 2 abort"One or more test have been failed" } if } if

--- a/src/toncli/modules/utils/commands/command_classes/run_tests_command.py
+++ b/src/toncli/modules/utils/commands/command_classes/run_tests_command.py
@@ -3,6 +3,7 @@ import sys
 from toncli.modules.utils.test.tests import TestsRunner
 from toncli.modules.utils.system.argparse_fix import argv_fix
 
+
 class RunTestsCommand():
     def __init__(self, string_kwargs, parser: ArgumentParser):
         # Meh
@@ -14,4 +15,5 @@ class RunTestsCommand():
                         tests=real_argv[2:],
                         verbose=args.verbose,
                         output_results=args.output_results,
-                        run_tests_old_way=args.old)
+                        run_tests_old_way=args.old,
+                        silent=bool(args.silent))

--- a/src/toncli/modules/utils/parsers/parser_utils.py
+++ b/src/toncli/modules/utils/parsers/parser_utils.py
@@ -168,6 +168,8 @@ class ParserUtil():
                                     'mask is also possible via astrisks symbol __test_somecases_*')
         run_tests.add_argument("--verbose", "-v", type=int, default=0,
                                help='Prints more debug information')
+        run_tests.add_argument("--silent", "-s", type=int, default=0,
+                               help='Do not abort if tests have failed')
         run_tests.add_argument("--output-results", "-o", action='store_true',
                                help='Stores results as json')
         run_tests.add_argument("--old", action='store_true', help='In old versions of toncli tests had to have '

--- a/src/toncli/modules/utils/test/tests.py
+++ b/src/toncli/modules/utils/test/tests.py
@@ -24,7 +24,8 @@ class TestsRunner:
     def __init__(self):
         self.project_config = ProjectConf(getcwd())
 
-    def run(self, contracts: List[str], tests: List[str], verbose: int, output_results: bool = False, run_tests_old_way: bool = False):
+    def run(self, contracts: List[str], tests: List[str], verbose: int, output_results: bool = False,
+            run_tests_old_way: bool = False, silent: bool = False):
         logger.info(f"🌈 Start tests")
         if contracts is not None and len(contracts) > 0:
             real_contracts = []
@@ -34,7 +35,8 @@ class TestsRunner:
                     if config.name == item:
                         real_contracts.append(config)
         else:
-            real_contracts = list( filter( lambda p: len(p.func_tests_files_locations ) > 0, self.project_config.contracts ) )
+            real_contracts = list(
+                filter(lambda p: len(p.func_tests_files_locations) > 0, self.project_config.contracts))
 
         if not len(real_contracts):
             logger.error(f"😥 No contracts [{contracts}] are founded in project.yaml")
@@ -62,11 +64,12 @@ class TestsRunner:
                 'output_results': int(output_results),
                 'output_path': output_path,
                 'contract_data': contract.data,
-                'verbose': verbose
+                'verbose': verbose,
+                'silent': int(silent)
             }
 
             if tests is not None and len(tests) > 0:
-                parser      = FiftParser(contract.to_save_tests_location)
+                parser = FiftParser(contract.to_save_tests_location)
                 tests_found = parser.lookup_tests(tests)
                 if len(tests_found) > 0:
                     render_kwargs['tests'] = tests_found


### PR DESCRIPTION
![Screen Shot 2022-11-16 at 12 52 55 PM](https://user-images.githubusercontent.com/19264196/202148024-3ad97c93-ef75-40b3-8026-a255b2460640.png)

This made auto CI&CD process easy to abort if something go wrong. If you want to use old behavior, please use `--silent 1` flag 