### PR TITLE
Add json output with base64 on project build

### DIFF
--- a/src/toncli/modules/fift/save_boc_and_base64.fif
+++ b/src/toncli/modules/fift/save_boc_and_base64.fif
@@ -1,0 +1,25 @@
+"TonUtil.fif" include
+"Asm.fif" include
+"Color.fif" include
+
+$# 2 < { abort"At least two arguments is needed" } if
+2 :$1..n
+
+$1 "/" $+ constant build-path
+$2 constant code-file-name
+
+build-path +"boc/" code-file-name +".boc" $+ constant boc-path
+build-path code-file-name +".fif" $+ constant code-path
+build-path code-file-name +".json" $+ constant json-path
+
+code-path include constant code
+
+code 2 boc+>B boc-path B>file
+
+{ 34 chr $+ } : db-quote
+
+
+"{" db-quote  +"code" db-quote +": " db-quote code 2 boc+>B B>base64url db-quote $+ +"}" $>B  json-path B>file
+
+
+`

--- a/src/toncli/modules/utils/func/commands.py
+++ b/src/toncli/modules/utils/func/commands.py
@@ -9,14 +9,15 @@ from typing import Optional, List
 
 from colorama import Fore, Style
 
-from toncli.modules.utils.system.conf import config_folder, executable, getcwd
+from toncli.modules.utils.system.conf import config_folder, executable, getcwd, project_root
 from toncli.modules.utils.system.project_conf import ProjectConf, TonProjectConfig
 
 bl = Fore.CYAN
 gr = Fore.GREEN
 rs = Style.RESET_ALL
 
-def build(project_root: str,
+
+def build(ton_project_root: str,
           cwd: Optional[str] = None,
           func_args: List[str] = None,
           contracts: List[TonProjectConfig] = None) -> Optional[str]:
@@ -24,12 +25,12 @@ def build(project_root: str,
     build method params are :
         :param contracts: contracts to build
         :param func_args: add arguments to func
-        :param project_root: Files to build in needed order
+        :param ton_project_root: Files to build in needed order
         :param cwd: If you need to change root of running script pass it here
         :return:
     """
     if not contracts:
-        project_config = ProjectConf(project_root)
+        project_config = ProjectConf(ton_project_root)
         contracts = project_config.contracts
 
     if not func_args:
@@ -40,7 +41,16 @@ def build(project_root: str,
         output.append(
             build_files(contract.func_files_locations, contract.to_save_location, func_args, cwd))
 
+        real_cwd = getcwd() if not cwd else os.path.abspath(cwd)
+
+        save_boc_and_json_path = os.path.join(project_root, "modules/fift/save_boc_and_base64.fif")
+        save_boc_and_json = [os.path.abspath(executable['fift']), "-I", os.path.abspath(f"{config_folder}/fift-libs"),
+                             "-s", save_boc_and_json_path, os.path.join(real_cwd, "build"), contract.name]
+
+        check_output(save_boc_and_json, cwd=real_cwd, shell=False)
+
     return "\n".join(list(map(str, output)))
+
 
 def build_files(func_files_locations: List[str], to_save_location: str, func_args: List[str] = None,
                 cwd: Optional[str] = None):
@@ -63,8 +73,8 @@ def build_files(func_files_locations: List[str], to_save_location: str, func_arg
                      *[os.path.abspath(i) for i in func_files],
                      *[os.path.abspath(i) for i in func_files_locations]]
     get_output = check_output(build_command,
-                                        cwd=getcwd() if not cwd else os.path.abspath(cwd),
-                                        shell=False)
+                              cwd=getcwd() if not cwd else os.path.abspath(cwd),
+                              shell=False)
 
     if get_output:
         return get_output.decode()

--- a/src/toncli/modules/utils/system/conf.py
+++ b/src/toncli/modules/utils/system/conf.py
@@ -46,12 +46,15 @@ def getcwd():
 
     return path
 
-def get_subdirs( path: str ) -> list:
-    return [ sub_dir.name for sub_dir in os.scandir( path ) if sub_dir.is_dir() ]
+
+def get_subdirs(path: str) -> list:
+    return [sub_dir.name for sub_dir in os.scandir(path) if sub_dir.is_dir()]
+
 
 def get_projects() -> list:
-    project_loc = os.path.join( project_root, "projects" )
-    return get_subdirs( project_loc )
+    project_loc = os.path.join(project_root, "projects")
+    return get_subdirs(project_loc)
+
 
 # Create if not exist
 if not os.path.exists(os.path.abspath(f"{config_folder}/config.ini")):


### PR DESCRIPTION
![Screen Shot 2022-11-16 at 1 36 47 PM](https://user-images.githubusercontent.com/19264196/202158082-a3d06532-b630-4c70-b08c-236199602f34.png)

On build command in project add building of BOC and base64 with output to json file. It makes less difficult to create dApp from toncli project.