### PR TITLE
Fix negative output vm codes

### DIFF
--- a/src/toncli/modules/fift/run_test.fif.template
+++ b/src/toncli/modules/fift/run_test.fif.template
@@ -27,6 +27,7 @@ variable error-descriptions dictnew error-descriptions !
 "Cell underflow. Read from slice primitive tried to read more bits or references than there are" 9 add-error-description
 "Dictionary error. Error during manipulation with dictionary (hashmaps)" 10 add-error-description
 "Out of gas error. Thrown by TVM when the remaining gas becomes negative" 13 add-error-description
+"Out of gas error. Thrown by TVM when the remaining gas becomes negative" 14 add-error-description
 "Action list is invalid (OR) (Method id not found)" 32 add-error-description
 "Action is invalid or not supported. Set during action phase if current action can not be applied" 34 add-error-description
 "Not enough TONs. Message sends too much TON (or there is no enough TONs after deducting fees)" 37 add-error-description
@@ -244,6 +245,8 @@ verbose 0>
     =: total_gas_used
     =: next_c5
     =: next_c4
+
+    dup 0 < { -1 * } if
     =: exit_code
 
     depth tuple =: test_result


### PR DESCRIPTION
This is partial fix of #92 

The ideal fix will be catching such errors inside a testing VM, so we can write some test code on those cases.

![Screen Shot 2022-11-17 at 9 52 20 AM](https://user-images.githubusercontent.com/19264196/202376798-abaffa4c-6e0b-4b94-b37c-ef3eb8c74980.png)
