### PR TITLE
Fixed incorrect idict_get_ref? & udict_get_ref? declarations

### DIFF
--- a/src/toncli/lib/func-libs/stdlib.func
+++ b/src/toncli/lib/func-libs/stdlib.func
@@ -127,8 +127,8 @@ cell idict_set_ref(cell dict, int key_len, int index, cell value) asm(value inde
 cell udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
 (cell, ()) ~udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
 cell idict_get_ref(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETOPTREF";
-(cell, int) idict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETREF";
-(cell, int) udict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGETREF";
+(cell, int) idict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETREF" "NULLSWAPIFNOT";
+(cell, int) udict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGETREF" "NULLSWAPIFNOT";
 (cell, cell) idict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETGETOPTREF";
 (cell, cell) udict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETGETOPTREF";
 (cell, int) idict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDEL";


### PR DESCRIPTION
Applying ton master branch fix:
https://github.com/ton-blockchain/ton/blame/master/crypto/smartcont/stdlib.fc#L522
https://github.com/ton-blockchain/ton/commit/b640f068466b1244b69abd7acdbafd57fb147b7a#diff-bd02ff6fa1299e145b87bfc607ebca117825ff561217cd96382b8b7cdf7afdf6R522