### PR TITLE
Increase lite-client timeout

### DIFF
--- a/src/toncli/modules/utils/lite_client/commands.py
+++ b/src/toncli/modules/utils/lite_client/commands.py
@@ -53,7 +53,7 @@ def lite_client_execute_command(network: str, args: List[str], update_config=Fal
     :return:
     """
     network = get_network_config_path(network, update_config)
-    return [os.path.abspath(executable['lite-client']), "-v", "3", "--timeout", "3", "-C", network, *args]
+    return [os.path.abspath(executable['lite-client']), "-v", "3", "--timeout", "10", "-C", network, *args]
 
 
 def get_account_status(network: str, address: str, cwd: Optional[str] = None,


### PR DESCRIPTION
With current testnet condition, timeout 3 works in 2 out of 10 cases.
At least that's what i'm experiencing.
In any case, increased timeout won't hurt anybody, while too short one causes errors in valid cases.
